### PR TITLE
修改重建图片列表预览问题

### DIFF
--- a/dist/viewer.js
+++ b/dist/viewer.js
@@ -388,8 +388,11 @@
     if (!value) {
       return;
     }
+    if(!element){
+    	return;
+    }
 
-    if (isNumber(element.length)) {
+    if (typeof(element.length)!='undefined' && isNumber(element.length)) {
       forEach(element, function (elem) {
         removeClass(elem, value);
       });
@@ -1659,7 +1662,9 @@
       var index = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
 
       index = Number(index) || 0;
-
+      
+      index = index >= this.length?0:index;
+      
       if (!this.isShown) {
         this.index = index;
         return this.show();


### PR DESCRIPTION
问题:
当在原来的图片列表选中一个序号较大的图片后,重建图片列表的长度比该序号小,下次的viewer.show()无法预览图片
解决方法:
view方法内判断是否超出图片列表长度,是则重置为0
```
index = index >= this.length?0:index;
```
removeClass方法会出现element为undefined,解决办法:
```
if(!element){
    	return;
    }

    if (typeof(element.length)!='undefined' && isNumber(element.length)) {
      forEach(element, function (elem) {
        removeClass(elem, value);
      });
      return;
    }
```